### PR TITLE
Made a change to stub-consul-warden.yml to connect to correct cluster

### DIFF
--- a/templates/stub-consul-warden.yml
+++ b/templates/stub-consul-warden.yml
@@ -23,4 +23,4 @@ properties:
     service:
       name: (( meta.service_name ))
     cluster:
-      join_host: 10.244.4.6
+      join_host: 10.244.2.6


### PR DESCRIPTION
Made a change to stub-consul-warden.yml to connect to the correct cluster.

Changed join_host from 10.244.4.6 to join_host: 10.244.2.6 as redis vm process failes because
join_host: 10.244.4.6 does not exist.