### PR TITLE
Add required arg to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bosh -n deploy
 For AWS EC2, create a three-node clusterg:
 
 ```
-templates/make_manifest aws-ec2
+templates/make_manifest aws-ec2 normal
 bosh -n deploy
 ```
 


### PR DESCRIPTION
Executing `templates/make_manifest aws-ec2` gives the following error:

    usage: ./make_manifest aws-ec2 <normal|consul>

The error goes away when the command is switched to:

    templates/make_manifest aws-ec2 normal