### PR TITLE
Resolved security vulnerability when specifying password

### DIFF
--- a/jobs/acceptance-tests/templates/bin/run
+++ b/jobs/acceptance-tests/templates/bin/run
@@ -9,27 +9,76 @@ source /var/vcap/jobs/acceptance-tests/helpers/ctl_setup.sh 'acceptance-tests'
 EXITSTATUS=0
 
 PASSWORD_FLAG=""
-if [[ "${PASSWORD}X" != "X" ]]; then
-  PASSWORD_FLAG=" -a {PASSWORD}"
+if [[ -n "${PASSWORD}" ]]
+  then
+  PASSWORD_FLAG=" -a ${PASSWORD}"
 fi
 
+echo "-----"
+echo "TEST: Write/read to master"
 redis-cli -h $MASTER -p ${PORT}${PASSWORD_FLAG} set rats running
 rats=$(redis-cli -h $MASTER -p ${PORT}${PASSWORD_FLAG} get rats)
 
-if [[ "${rats}" == "running" ]]; then
-  echo "Write/read to master - passed"
+if [[ "${rats}" == "running" ]]
+then
+  echo "PASSED"
 else
-  echo "Write/read to master - failed"
+  echo "FAILED"
   EXITSTATUS=1
 fi
 
+echo "-----"
+echo "TEST: Read from slave"
 rats=$(redis-cli -h $SLAVE -p ${PORT}${PASSWORD_FLAG} get rats)
 
-if [[ "${rats}" == "running" ]]; then
-  echo "Read from slave - passed"
+if [[ "${rats}" == "running" ]]
+then
+  echo "PASSED"
 else
-  echo "Read from slave - failed"
+  echo "FAILED"
   EXITSTATUS=1
+fi
+
+if [[ -n "${PASSWORD}" ]]
+then
+  echo "-----"
+  echo "TEST: Write/read to master: testing password requirement"
+  result="$(redis-cli -h $MASTER -p ${PORT} -a "not-the-${PASSWORD}" set rats testing-password-requirement)"
+  if [[ "$result" != *"NOAUTH Authentication required."* ]] 
+  then
+    echo "FAILED: Was able to write to master with incorrect password"
+    EXITSTATUS=2
+  fi
+  rats=$(redis-cli -h $MASTER -p ${PORT} -a "different-${PASSWORD}" get rats)
+  if [[ "$rats" != *"NOAUTH Authentication required."* ]] 
+  then
+    echo "FAILED: Was able to read from master with wrong password"
+    EXITSTATUS=2
+  fi
+  rats2=$(redis-cli -h $MASTER -p ${PORT} get rats)
+  if [[ "$rats2" != *"NOAUTH Authentication required."* ]] 
+  then
+    echo "FAILED: Was able to read from master with no password"
+    EXITSTATUS=2
+  fi
+
+  if [[ "${rats}" == "testing-password-requirement" ]]
+  then
+    echo "FAILED: Able to retrieve correct value with incorrect password"
+    EXITSTATUS=2
+  fi
+
+  if [[ "${rats2}" == "testing-password-requirement" ]]
+  then
+    echo "FAILED: Able to retrieve correct value with no password"
+    EXITSTATUS=2
+  fi
+  if [[ $EXITSTATUS == "2" ]]
+  then
+    EXITSTATUS=1
+  else
+    echo "PASSED"
+  fi
 fi
 
 exit $EXITSTATUS

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -169,6 +169,9 @@ slaveof <%= master %> <%= port %>
 # refuse the slave request.
 #
 # masterauth <master-password>
+<% if_p("redis.password") do |password| %>
+masterauth <%= password %>
+<% end %>
 
 # When a slave loses its connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
@@ -258,6 +261,9 @@ slave-priority 100
 # use a very strong password otherwise it will be very easy to break.
 #
 # requirepass foobared
+<% if_p("redis.password") do |password| %>
+requirepass <%= password %>
+<% end %>
 
 # Command renaming.
 #


### PR DESCRIPTION
Currently, if the password is specified, it isn't actually added to the two places in the configuration where it needs to be: the first is to set the password, and the second is for the the slave to be able to connect to the master.

After this change, the test results are:
```
[stdout]
$PATH /var/vcap/packages/redis-server/bin:/usr/sbin:/usr/bin:/sbin:/bin
-----
TEST: Write/read to master
OK
PASSED
-----
TEST: Read from slave
PASSED
-----
TEST: Write/read to master: testing password requirement
PASSED

[stderr]
None

Errand `acceptance-tests' completed successfully (exit code 0)
```