### PR TITLE
remove _cpi when setting $DIRECTOR_CPI, include howto install spiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ git clone https://github.com/cloudfoundry-community/redis-boshrelease.git
 cd redis-boshrelease
 ```
 
+Templates
+---------
+
+The `templates/make_manifest` uses [spiff](https://github.com/cloudfoundry-incubator/spiff), to install you can either download the binary release or add it through homebrew.
+
+```
+brew tap xoebus/cloudfoundry
+brew install spiff
+```
+
 For [bosh-lite](https://github.com/cloudfoundry/bosh-lite), you can quickly create a deployment manifest & deploy a three-node cluster:
 
 ```

--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -20,7 +20,7 @@ shift
 
 BOSH_STATUS=$(bosh status)
 DIRECTOR_UUID=$(echo "$BOSH_STATUS" | grep UUID | awk '{print $2}')
-DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}')
+DIRECTOR_CPI=$(echo "$BOSH_STATUS" | grep CPI | awk '{print $2}' | sed -e 's/_cpi//')
 DIRECTOR_NAME=$(echo "$BOSH_STATUS" | grep Name | sed -e 's/\s*Name\s*//')
 NAME=${NAME:-$template_prefix-$infrastructure}
 


### PR DESCRIPTION
In order to match what is being sent back by the `bosh public stemcells --full`, the `_cpi` needs to be removed from the end of the string.

The `templates/make_manifest` requires spiff to run.