### PR TITLE
make snapshot save intervals configurable

### DIFF
--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -35,7 +35,7 @@ properties:
       - 900 1
       - 300 10
       - 60 10000
-    description: save <seconds> <changes>; save points to the rdb snapshot either after #<seconds> seconds have passed or #<changes> changes have occurred
+    description: save <seconds> <changes>; save points to the rdb snapshot after #<seconds> seconds have passed if at least #<changes> key changes have occurred
 
   consul.service.name:
     description: Name for advertising/discovering this service over consul (defaults to deployment name)

--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -30,6 +30,12 @@ properties:
   base_dir:
     description: Base dir for storing database files
     default: /var/vcap/store/redis
+  redis_save_intervals:
+    default:
+      - 900 1
+      - 300 10
+      - 60 10000
+    description: save <seconds> <changes>; save points to the rdb snapshot either after #<seconds>seconds have passed of #<changes> changes have occurred
 
   consul.service.name:
     description: Name for advertising/discovering this service over consul (defaults to deployment name)

--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -35,7 +35,7 @@ properties:
       - 900 1
       - 300 10
       - 60 10000
-    description: save <seconds> <changes>; save points to the rdb snapshot either after #<seconds>seconds have passed of #<changes> changes have occurred
+    description: save <seconds> <changes>; save points to the rdb snapshot either after #<seconds> seconds have passed or #<changes> changes have occurred
 
   consul.service.name:
     description: Name for advertising/discovering this service over consul (defaults to deployment name)

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -105,9 +105,19 @@ databases 16
 #
 #   save ""
 
-save 900 1
-save 300 10
-save 60 10000
+<% if_p('redis_save_intervals') do
+    redis_save_intervals = p('redis_save_intervals')
+
+    if redis_save_intervals.length > 0
+        redis_save_intervals.each do | command |
+          %>save <%= command %>
+    <%
+        end
+   else
+       %>save ""<%
+   end
+end
+%>
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
Hello here,

I appreciate the simplicity of this release and its low entry configuration requirements, especially if compared with the other `redis` boshreleases.

This pull request aims, if possible, at simplifying the system requirements by giving the possibility to disable `rdb` snapshots altogether. This at the cost of an additional property and a bit of logic in the template.

The defaults are set so that the previous behavior remains unchanged if the property is not set.

## Changes:

add `redis_save_intervals` property to help configure or disable the rdb snapshot policies.

The `redis_save_intervals` property is an array in the form <seconds> <changes>.
Each entry in the array produces a correspondent:
```
save <seconds> <changes>
```
 line in the `redis.conf` configuration file.
Leaving the array empty produces a single 
```
save ""'
``` 
line disabling as a matter of fact rdb snapshotting