### PR TITLE
Enable bind to static IP. Implemented with new property in redis.conf

### DIFF
--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -33,6 +33,8 @@ properties:
       - 300 10
       - 60 10000
     description: save <seconds> <changes>; save points to the rdb snapshot after #<seconds> seconds have passed if at least #<changes> key changes have occurred
+  bind:
+    description: Specify this property if you would like to include or change the bind settings. 
 
   consul.service.name:
     description: Name for advertising/discovering this service over consul (defaults to deployment name)

--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -33,9 +33,9 @@ properties:
       - 300 10
       - 60 10000
     description: save <seconds> <changes>; save points to the rdb snapshot after #<seconds> seconds have passed if at least #<changes> key changes have occurred
-  bind:
-    description: Specify this property if you would like to include or change the bind settings. 
-
+  bind_static_ip:
+    description: Specify this property if you would like the bind address of a given instance to be automatically set to its assigned static IP
+    default: false
   consul.service.name:
     description: Name for advertising/discovering this service over consul (defaults to deployment name)
 

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -20,19 +20,23 @@ daemonize no
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= p("port") %>
 
-# If bind is specified in your manifest file, it will get set otherwise
-# it will fall back to default behavior, i.e. protected mode
-# 
+# If bind_static_ip is set to true in your manifest file, it will set the bind property
+# for each instance in your cluster to the static IP which was assigned to the instance
+# If it is set to false, it will not set the bind property which will force it to 
+# fall back to default behavior, i.e. protected mode due to bind not being set
+#  
+# bind_static_ip true
+#
+<% if_p("bind_static_ip") do |bind_static_ip| %>
+<% if bind_static_ip == true %>
+bind <%= spec.ip %>
+<% end %>
+<% end %>
+
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
 # bind 127.0.0.1
-<% if_p("bind") do |bind| %>
-  <% if bind.to_s != "" %>
-    bind <%= p("bind") %>
-  <% end %>
-<% end %>
-
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -20,10 +20,19 @@ daemonize no
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= p("port") %>
 
+# If bind is specified in your manifest file, it will get set otherwise
+# it will fall back to default behavior, i.e. protected mode
+# 
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
 # bind 127.0.0.1
+<% if_p("bind") do |bind| %>
+  <% if bind.to_s != "" %>
+    bind <%= p("bind") %>
+  <% end %>
+<% end %>
+
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
Our environment does not require authentication at this point, but when deployed as is, protected mode does not allow our apps to communicate with the Redis instance. This PR will ensure that we can set the bind interface to an external IP, allowing the communication path we are looking for. 