### PR TITLE
Adds option to toggle replication on/off

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,1 @@
+* Adds the redis.replication true/false option

--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -53,3 +53,6 @@ properties:
   redis.maxclients:
     description: Set the max number of connected clients at the same time.
     default: 10000
+  redis.replication:
+    description: When set to false, master/slave replication will be disabled and all instances will run as standalone deployments.
+    default: true

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -174,9 +174,14 @@ dir "<%= p('base_dir') %>"
 # so for example it is possible to configure the slave to save the DB with a
 # different interval, or to listen to another port, and so on.
 #
+<% if_p("redis.replication") do |replication| %>
+<% if replication == true %>
 <% unless spec.bootstrap -%>
 slaveof <%= link("redis").instances.find {|redis| redis.bootstrap }.address %> <%= p("port") %>
 <% end -%>
+<% end %>
+<% end %>
+
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -175,7 +175,7 @@ dir "<%= p('base_dir') %>"
 # different interval, or to listen to another port, and so on.
 #
 <% if_p("redis.replication") do |replication| %>
-<% if replication == true %>
+<% if replication %>
 <% unless spec.bootstrap -%>
 slaveof <%= link("redis").instances.find {|redis| redis.bootstrap }.address %> <%= p("port") %>
 <% end -%>


### PR DESCRIPTION
Some of our deployments are multiple standalone redis nodes which all need to be master.  

This change adds the redis.replication true/false option.

