### PR TITLE
Resets log directory permissions to vcap to fix in-place upgrades

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+## Improvements
+
+When upgrading from release v12 to latest, redis fails to start because redis.log is owned by root.  This release resets ownership of /var/vcap/sys/log to vcap.

--- a/jobs/redis/templates/bin/pre_start.sh
+++ b/jobs/redis/templates/bin/pre_start.sh
@@ -22,3 +22,7 @@ chpst -u root:root sysctl -w net.core.somaxconn=65535
 #
 # Redis best practice is vm.overcommit_memory=1 (https://redis.io/topics/admin)
 chpst -u root:root sysctl vm.overcommit_memory=1
+
+
+# Earlier builds generated a redis.log owned by root.  This resets logs dir owners to vcap.
+chpst -u root:root chown -R vcap:vcap /var/vcap/sys/log

--- a/jobs/redis/templates/bin/pre_start.sh
+++ b/jobs/redis/templates/bin/pre_start.sh
@@ -23,6 +23,5 @@ chpst -u root:root sysctl -w net.core.somaxconn=65535
 # Redis best practice is vm.overcommit_memory=1 (https://redis.io/topics/admin)
 chpst -u root:root sysctl vm.overcommit_memory=1
 
-
 # Earlier builds generated a redis.log owned by root.  This resets logs dir owners to vcap.
 chpst -u root:root chown -R vcap:vcap /var/vcap/sys/log


### PR DESCRIPTION
When upgrading from release v12 to latest, redis fails to start because redis.log is owned by root.  

This PR resets ownership of /var/vcap/sys/log to vcap.