### PR TITLE
Adding redis.raw_config parameter to append arbitrary redis config parameters

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,15 @@
+## New properties
+
+Set any redis.conf parameters using redis.raw_config.  
+
+Example:
+```yaml
+properties:
+  redis:
+    raw_config: |
+      maxmemory-policy allkeys-lru
+      maxmemory-samples 10
+      databases 1
+      appendonly yes
+      maxmemory 6144mb
+```

--- a/jobs/redis/spec
+++ b/jobs/redis/spec
@@ -56,3 +56,6 @@ properties:
   redis.replication:
     description: When set to false, master/slave replication will be disabled and all instances will run as standalone deployments.
     default: true
+  redis.raw_config:
+    description: Block literal representing redis configuration.  Appended at the end of redis.conf, the raw values provided will take precedence over any other configuration properties
+    default: ""

--- a/jobs/redis/templates/config/redis.conf.erb
+++ b/jobs/redis/templates/config/redis.conf.erb
@@ -633,3 +633,12 @@ aof-rewrite-incremental-fsync yes
 #
 # include /path/to/local.conf
 # include /path/to/other.conf
+
+
+
+# Redis reads configs top to bottom.  This block enables us to inject 
+# raw config values to overwride any defaults or bosh release parameters
+<% if_p('redis.raw_config') do |redis_config| -%>
+<%= redis_config %>
+<% end -%>
+


### PR DESCRIPTION
Users of this BOSH release can now override any preceding configuration in redis.conf.  This should help to mitigate operators' manifest changes for future release updates.