### PR TITLE
Correct variable in use-sentinel-addresses.yml

### DIFF
--- a/manifests/operators/use-sentinel-addresses.yml
+++ b/manifests/operators/use-sentinel-addresses.yml
@@ -7,5 +7,5 @@
 - path: /instance_groups/name=redis/jobs/name=redis/properties?
   type: replace
   value:
-    password: ((redis_password))
+    password: ((redis-password))
     bind_static_ip: true


### PR DESCRIPTION
`redis-password` instead of `redis_password`