### PR TITLE
Updated sentinel.conf.erb to support auth to redis

### DIFF
--- a/jobs/redis-sentinel/templates/config/sentinel.conf.erb
+++ b/jobs/redis-sentinel/templates/config/sentinel.conf.erb
@@ -99,6 +99,12 @@ sentinel monitor mymaster <%= link("redis").instances.find {|redis| redis.bootst
 #
 # sentinel auth-pass mymaster MySUPER--secret-0123passw0rd
 
+<% link("redis").if_p("password") do |password| %>
+  <% if password.to_s != "" %>
+sentinel auth-pass mymaster <%= password %>
+  <% end %>
+<% end %>
+
 # sentinel down-after-milliseconds <master-name> <milliseconds>
 #
 # Number of milliseconds the master (or any attached replica or sentinel) should


### PR DESCRIPTION
`sentinel.conf` template will now use `password` property from the link, if set, to configure `sentinel auth-pass` parameter.  This allows sentinel to function when redis authentication is enabled