### PR TITLE
allow a LoadBalancer to be configured - generated or static IP

### DIFF
--- a/quarks/helm/redis/templates/ingress.yaml
+++ b/quarks/helm/redis/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- $root := . -}}
+{{- if .Values.features.ingress.enabled -}}
+{{- with $service := .Values.services.redis }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $root.Release.Name }}-public
+  labels:
+    app.kubernetes.io/component: "service"
+    app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
+    app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
+spec:
+  type: ClusterIP
+  selector:
+    quarks.cloudfoundry.org/instance-group-name: redis
+    quarks.cloudfoundry.org/deployment-name: {{ $root.Values.deployment_name }}
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+  type: {{ $service.type | quote }}
+  {{- if gt (len $service.externalIPs) 0 }}
+  externalIPs: {{ $service.externalIPs | toJson }}
+  {{- end }}
+  {{- if $service.clusterIP }}
+  clusterIP: {{ $service.clusterIP | quote }}
+  {{- end }}
+  {{- if $service.loadBalancerIP }}
+  loadBalancerIP: {{ $service.loadBalancerIP | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/quarks/helm/redis/values.yaml
+++ b/quarks/helm/redis/values.yaml
@@ -11,6 +11,19 @@ releases:
 cluster:
   instances: 1
 
+features:
+  ingress:
+    enabled: false
+
+# Service is only valid to set a external endpoints for the instance groups if
+# features.ingress.enabled is true.
+services:
+  redis:
+    type: LoadBalancer
+    externalIPs: []
+    clusterIP: ~
+    loadBalancerIP: ~
+
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []


### PR DESCRIPTION
The helm values used match the pattern used by kubecf helm chart.