### PR TITLE
Fix properties about sentinel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ Redis Sentinel provides high availability for Redis. In this bosh release, you c
 [...]
   - name: redis
     release: redis
+    properties:
+      bind_static_ip: true
+      password: ((redis_password)
   - name: redis-sentinel
     release: redis
-  properties:
-    bind_static_ip: true
-    password: ((redis_password)
 ```
 
 ### Update


### PR DESCRIPTION
The properties are applied for redis job and redis sentinel job, but they aren't used in redis sentinel spec.
https://github.com/cloudfoundry-community/redis-boshrelease/blob/master/jobs/redis-sentinel/spec

In addition, instance groups level properties are deprecated in favor of job level properties.
https://bosh.io/docs/manifest-v2/#instance-groups